### PR TITLE
Make OffloadedTimer copyable

### DIFF
--- a/modules/squarepine_core/misc/Utilities.h
+++ b/modules/squarepine_core/misc/Utilities.h
@@ -49,7 +49,7 @@ public:
     std::function<void()> callback;
 
 private:
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (OffloadedTimer)
+    JUCE_LEAK_DETECTOR (OffloadedTimer)
 };
 
 /** This is basic HighResolutionTimer wrapper where the provided callback function will be called.


### PR DESCRIPTION
It needs to be copyable if we want to use it inside function objects passed as std::functions. 